### PR TITLE
Add RSS output for Notion clipper link database tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .now
+.vercel

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ All endpoints are relative to the base URL: `https://potion-api.now.sh`
 
 Lists all entries in a full-page Notion table, along with additional details about each page. 
 
-The only query parameter is `?id=<notion-page-id>`. 
+Choose the table with the query parameter `?id=<notion-page-id>`. 
+
+Default output format is JSON. Change this to RSS with the query parameter `format=rss`. For RSS output to work, the table entries must have properties named `URL` and `Name` (the default fields that the Notion Clipper creates).
 
 ### /table-description
 
@@ -63,4 +65,4 @@ Most, but not all, of the common Notion blocks are supported at the moment:
 
 This project is built to be deployed on [Vercel](https://vercel.com/home). 
 
-For local development, install [Vercel's CLI](https://vercel.com/download) and run `now dev`. 
+For local development, install [Vercel's CLI](https://vercel.com/download) and run `vercel dev`. 

--- a/api/table.js
+++ b/api/table.js
@@ -8,6 +8,7 @@ const getAssetUrl = require("../notion/getAssetUrl")
 module.exports = async (req, res) => {
   const { id:queryId } = req.query
   const id = normalizeId(queryId)
+  const format = req.query.format ? req.query.format.toLowerCase() : 'json'
 
   if(!id) {
     return res.json({
@@ -51,6 +52,12 @@ module.exports = async (req, res) => {
   const subPages = tableData.result.blockIds
 
   const schema = tableData.recordMap.collection[collectionId].value.schema
+console.log(pageData.results[0].value);
+  var feed
+  if(format == 'rss') {
+    var RSS = require('rss');
+    feed = new RSS();
+  }
 
   const output = []
 
@@ -101,8 +108,19 @@ module.exports = async (req, res) => {
       created: page.value.created_time,
       last_edited: page.value.last_edited_time
     })
+    if(format == 'rss') {
+      feed.item({
+        title:  fields.Name,
+        url: fields.URL, 
+        guid: page.value.id, // optional - defaults to url
+        date: page.value.last_edited_time
+      });
+    }
   })
 
-
-  return res.json(output)
+  if(format == 'rss') {
+    return res.send(feed.xml())
+  } else {
+    return res.json(output)
+  }
 }

--- a/api/table.js
+++ b/api/table.js
@@ -112,7 +112,7 @@ console.log(pageData.results[0].value);
       feed.item({
         title:  fields.Name,
         url: fields.URL, 
-        guid: page.value.id, // optional - defaults to url
+        guid: page.value.id,
         date: page.value.last_edited_time
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,19 @@
         "commander": "^2.19.0"
       }
     },
+    "mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+    },
+    "mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+      "requires": {
+        "mime-db": "~1.25.0"
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -55,6 +68,15 @@
         "clipboard": "^2.0.0"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      }
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
@@ -66,6 +88,11 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "optional": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "katex": "^0.11.1",
     "node-fetch": "^2.6.0",
-    "prismjs": "^1.19.0"
+    "prismjs": "^1.19.0",
+    "rss": "^1.2.2"
   }
 }


### PR DESCRIPTION
The default link database that the notion clipper creates has well-known fields. This PR takes those fields and builds an RSS feed of the link database. It also updates .gitignore to have the new name for the vercel CLI files.

To use, add a new `format` query string variable to your request and set it to `rss` (case-insensitive). For example: `/table?id=676ba0ce3fa84ff384706c452f69c489&format=rss`