### PR TITLE
Fix image block loading

### DIFF
--- a/api/html.js
+++ b/api/html.js
@@ -128,7 +128,7 @@ module.exports = async (req, res) => {
     } else if(["divider"].includes(type)) {
       html.push(`<hr>`)
     } else if(["image"].includes(type)) {
-      html.push(`<img src="https://www.notion.so/image/${encodeURIComponent(block.format.display_source)}">`)
+      html.push(`<img src="https://www.notion.so/image/${encodeURIComponent(block.format.display_source)}?table=block&id=${block.id}">`)
     } else if(["equation"].includes(type)) {
       if(!block.properties) {
         // Equation block is empty


### PR DESCRIPTION
Resolves #4 

Looks like Notion made a change very recently to lock down the `notion.so/image` proxy. 

This PR adds the required parameters that the error hints at: `table=block` (not quite sure what this means... might mean that this `notion.so/image` API can also be used for files uploaded in a table now?) and `id` being the block's ID. It looks like they use this `id` to verify that the current user (or lack of current user, if not logged in) can access this image _through_ viewing a specific block. 