### PR TITLE
Replaced queryCollection and syncRecordValues with loadPageChunk

### DIFF
--- a/api/table-description.js
+++ b/api/table-description.js
@@ -15,13 +15,21 @@ module.exports = async (req, res) => {
   }
 
   const {recordMap} = await call("loadPageChunk", {
-    requests: [
-      {
-        id: id,
-        table: "block",
-        version: -1
-      }
-    ]
+    pageId: id,
+    limit: 100,
+    cursor: {
+      stack: [
+        [
+          {
+            table: "block",
+            id: id, 
+            index: 0
+          }
+        ]
+      ]
+    },
+    chunkNumber: 0,
+    verticalColumns: false
   });
 
   const collectionBlock = recordMap.block[id].value;

--- a/api/table-description.js
+++ b/api/table-description.js
@@ -14,7 +14,7 @@ module.exports = async (req, res) => {
     })
   }
 
-  const pageData = await call("syncRecordValues", {
+  const {recordMap} = await call("loadPageChunk", {
     requests: [
       {
         id: id,
@@ -24,7 +24,7 @@ module.exports = async (req, res) => {
     ]
   });
 
-  const collectionBlock = pageData.recordMap.block[id].value;
+  const collectionBlock = recordMap.block[id].value;
 
   if(!collectionBlock) {
     return res.json({
@@ -38,18 +38,7 @@ module.exports = async (req, res) => {
     })
   }
 
-  const collectionId = collectionBlock.collection_id
-  const collectionViewId = collectionBlock.view_ids[0]
-
-  const tableData = await call("queryCollection", {
-    collectionId,
-    collectionViewId,
-    loader: {
-      type: "table"
-    }
-  });
-
-  const descriptionArray = tableData.recordMap.collection[collectionId].value.description;
+  const descriptionArray = recordMap.collection[collectionBlock.collection_id].value.description;
 
   res.send(textArrayToHtml(descriptionArray))
 }


### PR DESCRIPTION
Previously two separate api rquests were made to `queryCollection` and `syncRecordValues` endpoints to fetch the necessary data. But since we only need the collection description, it can be fetched using a single API request to the `loadPageChunk` endpoint with the right payload. The response contains the collection_views and the collection associated with the block along with the block itself.